### PR TITLE
Updates to match latest documentation

### DIFF
--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -28,7 +28,7 @@ module "user_data" {
   resource_name_prefix  = "dev"
   subscription_id       = data.azurerm_client_config.current.subscription_id
   tenant_id             = data.azurerm_client_config.current.tenant_id
-  vault_version         = "1.8.0"
+  vault_version         = "1.8.1"
   vm_scale_set_name     = "dev-vault"
 
   resource_group = {

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -48,7 +48,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "vault_cluster" {
 
   os_disk {
     caching              = "ReadWrite"
-    disk_size_gb         = 50
+    disk_size_gb         = 1024
     storage_account_type = var.os_disk_type
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -150,7 +150,7 @@ variable "vault_license_filepath" {
 }
 
 variable "vault_version" {
-  default     = "1.8.0"
+  default     = "1.8.1"
   description = "Vault version"
   type        = string
 }


### PR DESCRIPTION
Make some updates to match the latest documentation:
* Update config and file permissions to match Deployment Guide
* Update disk specs to new Reference Architecture recommendations
* Update default version to 1.8.1