### PR TITLE
reduce vm role definition scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+**NOTE:** The role definition change incurs no direct downtime, but requires Terraform to replace two resources. This will fail initially due to the role definition's fixed name (Terraform will generate an error when attempting to create a replacement with the same name). To work around this, delete the role definition and its assignment first:
+
+```bash
+az role assignment delete --ids /subscriptions/SUBSCRIPTIONGUIDHERE/resourceGroups/myresourcegroupname/providers/Microsoft.Authorization/roleAssignments/ROLEASSIGNMENTGUID
+
+az role definition delete --name my-resource-name-prefix-vault-server --scope /subscriptions/SUBSCRIPTIONGUIDHERE
+```
+The role assignment ID, subscription GUID, and role definition name will be displayed by Terraform via `terraform plan`
+
+* Reduced deployment scope for the VM role definition to its Resource Group
+
 ## 0.1.1 (August 27, 2021)
 
 * Update TLS directory permissions

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,5 +1,3 @@
-data "azurerm_subscription" "current" {}
-
 resource "azurerm_user_assigned_identity" "vault" {
   count = var.user_supplied_vm_identity_id != null ? 0 : 1
 
@@ -31,7 +29,7 @@ resource "azurerm_role_definition" "vault" {
   count = var.user_supplied_vm_identity_id != null ? 0 : 1
 
   name  = "${var.resource_name_prefix}-vault-server"
-  scope = data.azurerm_subscription.current.id
+  scope = var.resource_group.id
 
   assignable_scopes = [
     var.resource_group.id,


### PR DESCRIPTION
This will allow deployments to be performed by IAM principals with access only to the Resource Group.

The significant downside to this is that upgrades from a prior version require user intervention. I've made a note in the changelog documenting workaround steps.