### PR TITLE
update tls example key vault certificate to include tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+**NOTE:** The example tls module Key Vault Certificate resource change will prompt Terraform to replace it (resulting in an error because of the resource's fixed name). To work around this, manually update the certificate's tags to match the desired state in Terraform. E.g.:
+
+```bash
+az keyvault certificate set-attributes --vault-name KEYVAULTNAME --name RESOURCEPREFIX-vault-cert --tags TAGKEY=TAGNAME
+```
+* Updated example TLS Key Vault Certificate resource to include resource tags
+
 ## 0.1.1 (August 27, 2021)
 
 * Update TLS directory permissions

--- a/examples/tls/main.tf
+++ b/examples/tls/main.tf
@@ -73,6 +73,7 @@ resource "azurerm_key_vault_access_policy" "vault" {
 resource "azurerm_key_vault_certificate" "vault" {
   key_vault_id = azurerm_key_vault_access_policy.vault.key_vault_id
   name         = "${var.resource_name_prefix}-vault-cert"
+  tags         = var.common_tags
 
   certificate {
     contents = filebase64("certificate-to-import.pfx")


### PR DESCRIPTION
This updates the example Key Vault Certificate resource to include tags from the module variables.

The significant downside to this is that upgrades from a prior version [require user intervention](https://github.com/hashicorp/terraform-provider-azurerm/issues/13315). I've made a note in the changelog documenting workaround steps.