### PR TITLE
add tag properties to additional example resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Add resource tags to 2 additional example resources (`azurerm_bastion_host` & `azurerm_key_vault_certificate`)
+* Add explicit NAT Gateway association dependency to example vnet subnet id output
+
 ## 0.1.1 (August 27, 2021)
 
 * Update TLS directory permissions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Add resource tags to 2 additional example resources (`azurerm_bastion_host` & `azurerm_key_vault_certificate`)
+* Add resource tags to 3 additional example resources (`azurerm_bastion_host`, `azurerm_key_vault_certificate`, & `azurerm_key_vault_secret`)
 * Add explicit NAT Gateway association dependency to example vnet subnet id output
 
 ## 0.1.1 (August 27, 2021)

--- a/examples/tls/main.tf
+++ b/examples/tls/main.tf
@@ -100,5 +100,6 @@ resource "azurerm_key_vault_certificate" "vault" {
 resource "azurerm_key_vault_secret" "vault" {
   key_vault_id = azurerm_key_vault_access_policy.vault.key_vault_id
   name         = "${var.resource_name_prefix}-vault-vm-tls"
+  tags         = var.common_tags
   value        = filebase64("certificate-to-import.pfx")
 }

--- a/examples/tls/main.tf
+++ b/examples/tls/main.tf
@@ -73,6 +73,7 @@ resource "azurerm_key_vault_access_policy" "vault" {
 resource "azurerm_key_vault_certificate" "vault" {
   key_vault_id = azurerm_key_vault_access_policy.vault.key_vault_id
   name         = "${var.resource_name_prefix}-vault-cert"
+  tags         = var.common_tags
 
   certificate {
     contents = filebase64("certificate-to-import.pfx")

--- a/examples/vnet/main.tf
+++ b/examples/vnet/main.tf
@@ -276,6 +276,7 @@ resource "azurerm_bastion_host" "main" {
   location            = var.resource_group.location
   name                = "${var.resource_name_prefix}-vault-abs"
   resource_group_name = var.resource_group.name
+  tags                = var.common_tags
 
   ip_configuration {
     name                 = "${var.resource_name_prefix}-vault-abs"

--- a/examples/vnet/outputs.tf
+++ b/examples/vnet/outputs.tf
@@ -16,6 +16,10 @@ output "vault_network_security_group_name" {
 
 output "vault_subnet_id" {
   value = azurerm_subnet_network_security_group_association.vault.id
+
+  depends_on = [
+    azurerm_subnet_nat_gateway_association.vault,
+  ]
 }
 
 output "virtual_network_name" {


### PR DESCRIPTION
These resources now have tags consistently applied like the others.

Also added an explicit dependency to one of the example outputs. In practice this almost certainly didn't cause any problems to have it omitted (the resources would finish creation long before they were needed), but this will help guarantee the subnet is not used before being completely set up.