### PR TITLE
Update case of permissions in IAM module

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -17,13 +17,13 @@ resource "azurerm_key_vault_access_policy" "vault_msi" {
   tenant_id    = var.tenant_id
 
   key_permissions = [
-    "get",
-    "unwrapKey",
-    "wrapKey",
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
   ]
 
   secret_permissions = [
-    "get",
+    "Get",
   ]
 }
 
@@ -69,6 +69,6 @@ resource "azurerm_key_vault_access_policy" "load_balancer_msi" {
   tenant_id    = var.tenant_id
 
   secret_permissions = [
-    "get",
+    "Get",
   ]
 }


### PR DESCRIPTION
This is a relatively minor change. As is, Terraform deploys successfully and then on subsequent deploys reports that the resources changed outside of Terraform, e.g.:

```
  # module.vault_ent.module.iam.azurerm_key_vault_access_policy.load_balancer_msi[0] has been changed
  ~ resource "azurerm_key_vault_access_policy" "load_balancer_msi" {
      ...
      ~ secret_permissions      = [
          - "get",
          + "Get",
        ]

```

This update just prevents the cosmetic issue from appearing on the second deploy.