### PR TITLE
drop unused variable from user_data submodule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,6 @@ module "user_data" {
   leader_tls_servername       = var.leader_tls_servername
   license_secret_id           = module.license_storage.license_secret_id
   resource_group              = var.resource_group
-  resource_name_prefix        = var.resource_name_prefix
   subscription_id             = data.azurerm_client_config.current.subscription_id
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   user_supplied_userdata_path = var.user_supplied_userdata_path

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -7,7 +7,6 @@
 * `key_vault_secret_id` - ID of Key Vault Secret in which Vault TLS PFX bundle is stored
 * `leader_tls_servername` - DNS name to use when checking certificate names of other Vault servers
 * `resource_group` - Resource group in which resources will be deployed
-* `resource_name_prefix` - Prefix placed before resource names
 * `subscription_id` - ID of Azure subscription
 * `tenant_id` - Tenant ID for Azure subscription in which resources are being deployed
 * `vault_version` - Version of Vault Enterprise to deploy
@@ -25,7 +24,6 @@ module "user_data" {
   key_vault_name        = "mykeyvaultname"
   key_vault_secret_id   = "https://mykeyvaultname.vault.azure.net/secrets/mykeyvaultsecretname/12ab12ab12ab12ab12ab12ab12ab12ab"
   leader_tls_servername = "vault.server.com"
-  resource_name_prefix  = "dev"
   subscription_id       = data.azurerm_client_config.current.subscription_id
   tenant_id             = data.azurerm_client_config.current.tenant_id
   vault_version         = "1.8.1"

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -7,7 +7,6 @@ locals {
       key_vault_secret_id   = var.key_vault_secret_id
       license_secret_id     = var.license_secret_id
       leader_tls_servername = var.leader_tls_servername
-      name                  = var.resource_name_prefix
       resource_group_name   = var.resource_group.name
       subscription_id       = var.subscription_id
       tenant_id             = var.tenant_id

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -31,11 +31,6 @@ variable "resource_group" {
   })
 }
 
-variable "resource_name_prefix" {
-  description = "Prefix applied to resource names"
-  type        = string
-}
-
 variable "subscription_id" {
   description = "Azure Subscription ID"
   type        = string


### PR DESCRIPTION
The `resource_name_prefix` variable isn't actually used by the template.