### PR TITLE
switch to user_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Switch VM configuration to use user_data instead of custom_data
 
 ## 0.1.1 (August 27, 2021)
 

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -7,14 +7,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "vault_cluster" {
   resource_group_name = var.resource_group.name
   sku                 = var.instance_type
   source_image_id     = var.user_supplied_source_image_id
+  user_data           = var.user_data
   zone_balance        = var.zones == null ? false : true
   zones               = var.zones
-
-  # user_data = var.user_data
-  # Actual "userData" support is pending in Terraform
-  # https://github.com/terraform-providers/terraform-provider-azurerm/issues/11846
-  # Fine to just use with the legacy custom_data API instead
-  custom_data = var.user_data
 
   additional_capabilities {
     ultra_ssd_enabled = var.ultra_ssd_enabled

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.15"
 
   required_providers {
-    azurerm = ">=2.0"
+    azurerm = ">=2.91"
   }
 }


### PR DESCRIPTION
[Latest TF provider](https://github.com/hashicorp/terraform-provider-azurerm/blob/v2.91.0/CHANGELOG.md#2910-january-07-2022) supports the newer [user_data](https://docs.microsoft.com/en-us/azure/virtual-machines/user-data) API.

Confirmed to deploy/upgrade without issues:

```
  # module.vault_ent.module.vm.azurerm_linux_virtual_machine_scale_set.vault_cluster will be updated in-place
  ~ resource "azurerm_linux_virtual_machine_scale_set" "vault_cluster" {
      - custom_data                                       = (sensitive value)
        ...
      + user_data                                         = "<BASE64VALUEHERE...>"
```